### PR TITLE
support both Duo and Browserify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+- 0.11
+- 0.12
+- iojs

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# Unreleased
+  * add npm support
+  * use duo for testing
 
 # 0.1.1 (7/30/2014)
  * using the "brute force" search as a fallback for IE (see 8b71ddb4ec7514041bc29abc68d5e8ef6b580bd2)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # form-element
 
+[![npm][npm-image]][npm-url]
+[![travis][travis-image]][travis-url]
+
+[npm-image]: https://img.shields.io/npm/v/form-element.svg?style=flat-square
+[npm-url]: https://www.npmjs.com/package/form-element
+[travis-image]: https://img.shields.io/travis/dominicbarnes/form-element.svg?style=flat-square
+[travis-url]: https://travis-ci.org/dominicbarnes/form-element
+
 A cross-browser helper function to retrieve a form control by name.
+
+## Install
+
+  `npm install form-element`
 
 ## Usage
 

--- a/component.json
+++ b/component.json
@@ -9,16 +9,14 @@
     "input",
     "helper"
   ],
+  "dependencies": {
+    "component/domify": "*",
+    "component/value": "*"
+  },
   "development": {
     "dependencies": {
-      "component/assert": "*",
-      "component/domify": "*",
-      "component/value": "*",
-      "visionmedia/mocha": "*"
-    },
-    "templates": [
-      "test/form.html"
-    ]
+      "component/assert": "*"
+    }
   },
   "scripts": [
     "index.js"

--- a/package.json
+++ b/package.json
@@ -1,24 +1,36 @@
 {
   "name": "form-element",
+  "description": "A cross-browser helper function to retrieve a form control by name.",
   "version": "0.1.1",
+  "author": "Dominic Barnes",
   "browser": {
     "value": "component-value"
   },
-  "dependencies": {
-    "component": "^1.0.0",
-    "component-test": "*"
-  },
+  "bugs": "https://github.com/dominicbarnes/form-element/issues",
+  "dependencies": {},
   "devDependencies": {
-    "component-test": "~0.1.3",
     "component-value": "^1.1.0",
     "domify": "^1.4.0",
     "duo-tester": "^0.1.1",
     "mochify": "^2.13.0",
     "stringify": "^3.1.0"
   },
+  "homepage": "https://github.com/dominicbarnes/form-element/",
+  "keywords": [
+    "browser",
+    "controls",
+    "form",
+    "html"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/dominicbarnes/form-element.git"
+  },
   "scripts": {
-    "test": "npm run test-duo && npm run test-node",
     "start": "duo-tester browser",
+    "test": "npm run test-duo && npm run test-node",
     "test-duo": "duo-tester phantomjs",
     "test-node": "mochify --transform stringify"
   }

--- a/package.json
+++ b/package.json
@@ -1,18 +1,25 @@
 {
-  "name": "dominicbarnes-form-element",
+  "name": "form-element",
   "version": "0.1.1",
+  "browser": {
+    "value": "component-value"
+  },
   "dependencies": {
     "component": "^1.0.0",
     "component-test": "*"
   },
   "devDependencies": {
-    "component-test": "~0.1.3"
+    "component-test": "~0.1.3",
+    "component-value": "^1.1.0",
+    "domify": "^1.4.0",
+    "duo-tester": "^0.1.1",
+    "mochify": "^2.13.0",
+    "stringify": "^3.1.0"
   },
   "scripts": {
-    "postinstall": "component install --dev",
-    "build": "component build --dev",
-    "pretest": "npm run build",
-    "test": "component test phantom",
-    "start": "component test browser"
+    "test": "npm run test-duo && npm run test-node",
+    "start": "duo-tester browser",
+    "test-duo": "duo-tester phantomjs",
+    "test-node": "mochify --transform stringify"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,8 @@
 var assert = require("assert");
 var domify = require("domify");
-var element = require("form-element");
+var element = require("../index.js");
 var value = require("value");
-var form = domify(require("form-element/test/form.html"));
+var form = domify(require("./form.html"));
 
 describe("element(root, name)", function () {
     it("should retrieve the username field", function () {


### PR DESCRIPTION
`npm run test` will run tests through both Duo and Browserify, and I added a .travis.yml if you want to turn CI on.  `form-element` on npm is still available if you'd be so kind as to publish this.  I'm on a mission to get `deku-forms` to work with Browserify.
